### PR TITLE
Correct a Typo 'Bakc home'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,7 +44,7 @@ en:
       replies: "Replies"
       site: "Site settings"
       fragments: "Fragments"
-      back_home: "Bakc home"
+      back_home: "Back home"
   shared:
     sidebar_login:
       header: "Join Discuss?"


### PR DESCRIPTION
Correct a Typo 'Bakc home' in config/locales/en.yml
