### PR TITLE
新功能：用户可已删除账户

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_filter :require_no_logined
+  before_filter :require_no_logined, :except => :destroy
 
   def new
     @user = User.new
@@ -14,5 +14,13 @@ class UsersController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    require_logined
+    current_user.destroy
+    flash[:success] = I18n.t('settings.accounts.show.delete_success', :name => current_user.name)
+    logout
+    redirect_back_or_default root_url
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_filter :require_no_logined, :except => :destroy
+  before_filter :require_logined, :only => :destroy
 
   def new
     @user = User.new
@@ -17,7 +18,6 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    require_logined
     current_user.destroy
     flash[:success] = I18n.t('settings.accounts.show.delete_success', :name => current_user.name)
     logout

--- a/app/views/settings/accounts/show.haml
+++ b/app/views/settings/accounts/show.haml
@@ -23,3 +23,7 @@
       .controls
         = f.password_field :current_password, :class => 'span3'
     = f.submit t('save'), :class => 'btn primary'
+%header
+  %h3= t('.danger_action')
+= button_to t('.delete_user'), user_path(current_user), :method => :delete, :class => 'btn btn-danger', :data => {:confirm => t('.delete_confirm', :name => current_user.name)}
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -84,6 +84,10 @@ en:
     accounts:
       show:
         account_settings: "Account settings"
+        danger_action: "Danger Action"
+        delete_user: "Delete User"
+        delete_confirm: "Are you sure destroy user %{name} ? (Topics and Replies will be destroy together)"
+        delete_success: "success destroy user %{name}"
     passwords:
       show:
         password_settings: "Password settings"

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -84,6 +84,10 @@ zh-CN:
     accounts:
       show:
         account_settings: "账户设置"
+        danger_action: "高危操作"
+        delete_user: "删除账户"
+        delete_confirm: "确认删除用户 %{name} 吗？（主题和回复会被一并删除且不能恢复）"
+        delete_success: "成功删除用户 %{name}"
     passwords:
       show:
         password_settings: "密码设置"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ CodeCampo::Application.routes.draw do
   get 'signup' => 'users#new', :as => :signup
   get 'login' => 'user_sessions#new', :as => :login
   delete 'logout' => 'user_sessions#destroy', :as => :logout
-  resources :users, :only => [:create]
+  resources :users, :only => [:create, :destroy]
+
   resources :user_sessions, :only => [:create]
 
   resource :search, :controller => 'search', :only => 'show'


### PR DESCRIPTION
Update at 2012-08-07
按照 @chloerei 所述的方式重新实现。

<del>永久注销规则：

1.  删除该用户所有话题、评论；
2.  永久注销后无法登录， **不可撤销** 。
2.  用户其他资料保留，非管理员无法查看；
3.  只有用户自身可以永久注销， 管理员也不行。
</del>
