### PR TITLE
Update code_campo.scss

### DIFF
--- a/app/assets/stylesheets/code_campo.scss
+++ b/app/assets/stylesheets/code_campo.scss
@@ -96,6 +96,8 @@ table.clear-table {
 
 table.item-list {
   width: 100%;
+  table-layout: fixed;
+  width: 800px;
 
   tr {
     border-top: 1px solid #DDD;


### PR DESCRIPTION
回复的内容里包含大图片，table宽度就会超长，是不是该设置成固定宽度？
